### PR TITLE
Update KDE version

### DIFF
--- a/roles/kde/tasks/main.yml
+++ b/roles/kde/tasks/main.yml
@@ -6,8 +6,8 @@
     name: "{{ item }}"
     state: present
   with_items:
-    - kde5
-    - plasma5-sddm-kcm
+    - kde
+    - plasma6-sddm-kcm
     - sddm
     - networkmgr
 


### PR DESCRIPTION
The main KDE port was now renamed to "kde" instead of "kde6". Also chase update to plasma6.