### PR TITLE
Updates for FreeBSD 15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ FreeBSD works on our systems and helps you set it up.
 | Framework Laptop 13 | 13th Gen Intel Core         | Working well                        |
 | Framework Laptop 13 | Intel Core Ultra Series 1   | Working with DRM 6.6 (FreeBSD 15)   |
 | Framework Laptop 13 | AMD Ryzen 7040 Series       | Working with DRM 6.2 (FreeBSD 14.2) |
-| Framework Laptop 13 | AMD Ryzen AI 300 Series     | Working, no GUI yet                 |
+| Framework Laptop 13 | AMD Ryzen AI 300 Series     | Working with DRM 6.12 (FreeBSD 15.1) |
 | Framework Laptop 13 Pro | Intel Core Ultra Series 3 | |
 | Framework Laptop 16 | AMD Ryzen 7040 Series       | Working with DRM 6.2 (FreeBSD 14.2) |
 | Framework Laptop 16 | AMD Ryzen AI 300 Series     | Working well with nvidia GPU        |
@@ -97,7 +97,9 @@ TODO: KDE on Wayland
 
 - [x] AMD GPU driver (Ryzen 7040 Series)
   - Working with `drm-61-kmod`
-- [ ] AMD GPU driver (Ryzen AI 300/Max)
+- [x] AMD GPU driver (Ryzen AI 300 Series)
+  - Working with `drm-612-kmod`
+- [ ] AMD GPU driver (Ryzen AI Max 300 Series)
   - Not working with `drm-66-kmod`
   - amdgpu 6.6 fails to attach, "Fatal error during GPU init"
 - [ ] Suspend (S0ix)

--- a/installation-instructions.md
+++ b/installation-instructions.md
@@ -2,14 +2,15 @@
 
 ## Download and burn ISO
 
-For the following systems, please use the latest development snapshot: [FreeBSD 15-CURRENT](https://download.freebsd.org/snapshots/amd64/amd64/ISO-IMAGES/15.0/).
+Most systems are running fine on the latest stable release
+[FreeBSD 15.1](https://download.freebsd.org/releases/amd64/amd64/ISO-IMAGES/15.1/FreeBSD-15.1-RELEASE-amd64-disc1.iso).
+
+In case your device is not fully supported yet you can try a development snapshot:
+[FreeBSD 16-CURRENT](https://download.freebsd.org/snapshots/amd64/amd64/ISO-IMAGES/16.0/).
 
 - Framework 13 - Intel Core Ultra Series 1 (Released  Summer 2024)
-- Framework 13 - AMD Ryzen AI 300 (Released Spring 2025)
 - Framework Desktop - AMD Ryzen AI Max 300 (Released Spring 2025)
 
-All other systems can use the latest stable release
-[FreeBSD 14.2](https://download.freebsd.org/ftp/releases/ISO-IMAGES/14.2/FreeBSD-14.2-RELEASE-amd64-dvd1.iso).
 
 Burn the ISO to a USB thumb drive using your favorite imager.
 For example dd, [Rufus](https://rufus.ie/en/), or [balena etcher](https://etcher.balena.io/).


### PR DESCRIPTION
AMD Ryzen AI 340 is working fine on FreeBSD 15.1 using drm-612-kmod (which is available in ports now) on Xfce. I assume it's the same for AI 350.

I've also updated the download links in the installation instructions and changed the order to recommend using FreeBSD releases which should be fine for the majority of systems nowadays.

I've had a look a the Ansible recipes but they look quite a bit outdated so I am not sure what to do about them. Any recommendations?